### PR TITLE
Introduce round robin for ETL dir assignment

### DIFF
--- a/src/main/java/life/qbic/data/processing/AppConfig.java
+++ b/src/main/java/life/qbic/data/processing/AppConfig.java
@@ -1,6 +1,7 @@
 package life.qbic.data.processing;
 
 import java.nio.file.Path;
+import java.util.Arrays;
 import life.qbic.data.processing.config.EvaluationWorkersConfig;
 import life.qbic.data.processing.config.ProcessingWorkersConfig;
 import life.qbic.data.processing.config.RegistrationWorkersConfig;
@@ -50,17 +51,17 @@ class AppConfig {
   EvaluationWorkersConfig evaluationWorkersConfig(
       @Value("${evaluations.threads}") int amountOfWorkers,
       @Value("${evaluation.working.dir}") String workingDirectory,
-      @Value("${evaluation.target.dir}") String targetDirectory,
+      @Value("${evaluation.target.dirs}") String[] targetDirectory,
       @Value("${evaluation.measurement-id.pattern}") String measurementIdPattern) {
-    return new EvaluationWorkersConfig(amountOfWorkers, workingDirectory, targetDirectory,
-        measurementIdPattern);
+    return new EvaluationWorkersConfig(amountOfWorkers, workingDirectory,
+        measurementIdPattern, Arrays.stream(targetDirectory).toList());
   }
 
   @Bean
   EvaluationConfiguration evaluationConfiguration(EvaluationWorkersConfig evaluationWorkersConfig,
       GlobalConfig globalConfig) {
     return new EvaluationConfiguration(evaluationWorkersConfig.workingDirectory().toString(),
-        evaluationWorkersConfig.targetDirectory().toString(),
+        evaluationWorkersConfig.targetDirectories(),
         evaluationWorkersConfig.measurementIdPattern().toString(), globalConfig);
   }
 

--- a/src/main/java/life/qbic/data/processing/config/EvaluationWorkersConfig.java
+++ b/src/main/java/life/qbic/data/processing/config/EvaluationWorkersConfig.java
@@ -2,28 +2,36 @@ package life.qbic.data.processing.config;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collection;
 import java.util.regex.Pattern;
 
 public class EvaluationWorkersConfig {
 
   private final int threads;
   private final Path workingDirectory;
-  private final Path targetDirectory;
+  private final Collection<Path> targetDirectories;
   private final Pattern measurementIdPattern;
 
-  public EvaluationWorkersConfig(int threads, String workingDirectory, String targetDirectory, String measurementIdPattern) {
+  public EvaluationWorkersConfig(int threads, String workingDirectory, String measurementIdPattern,
+      Collection<String> targetDirectories) {
     if (threads < 1) {
-      throw new IllegalArgumentException("Number of evaluation worker threads must be greater than 0");
+      throw new IllegalArgumentException(
+          "Number of evaluation worker threads must be greater than 0");
+    }
+    if (targetDirectories.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Target directories cannot be empty, please specify at least one target directory");
     }
     this.threads = threads;
     this.workingDirectory = Paths.get(workingDirectory);
     if (!this.workingDirectory.toFile().exists()) {
       throw new IllegalArgumentException("Evaluation worker directory does not exist");
     }
-    this.targetDirectory = Paths.get(targetDirectory);
-    if (!this.targetDirectory.toFile().exists()) {
-      throw new IllegalArgumentException("Evaluation target directory does not exist");
-    }
+    this.targetDirectories = targetDirectories.stream().map(Paths::get).toList();
+    this.targetDirectories.stream().filter(path -> !path.toFile().exists()).forEach(path -> {
+      throw new IllegalArgumentException(
+          "Evaluation target directory '%s' does not exist".formatted(path));
+    });
     if (measurementIdPattern.isBlank()) {
       throw new IllegalArgumentException("Measurement id pattern cannot be blank");
     }
@@ -38,8 +46,8 @@ public class EvaluationWorkersConfig {
     return workingDirectory;
   }
 
-  public Path targetDirectory() {
-    return targetDirectory;
+  public Collection<Path> targetDirectories() {
+    return targetDirectories;
   }
 
   public Pattern measurementIdPattern() {

--- a/src/main/java/life/qbic/data/processing/config/RoundRobinDraw.java
+++ b/src/main/java/life/qbic/data/processing/config/RoundRobinDraw.java
@@ -4,11 +4,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 /**
- * <b><class short description - 1 Line!></b>
+ * <b>Round Robin Draw</b>
+ * <p>
+ * Enables a thread-safe access of items in a given collection based on the round robin method.
  *
- * <p><More detailed description - When to use, what it solves, etc.></p>
- *
- * @since <version tag>
+ * @since 1.0.0s
  */
 public class RoundRobinDraw<T> {
 
@@ -21,13 +21,29 @@ public class RoundRobinDraw<T> {
     this.itemsAmount = items.size();
   }
 
-  public static <T> RoundRobinDraw<T> create(Collection<T> items) {
-    if (items.isEmpty()) {
-      throw new IllegalArgumentException("Empty collection");
+  /**
+   * Creates an instance of {@link RoundRobinDraw} based on the type {@link T} of the collection provided
+   * @param items a collection of items the round robin method shall be applied.
+   * @return an instance of this class
+   * @throws IllegalArgumentException if an empty collection is provided or the collection is <code>null</code>
+   * @since 1.0.0
+   */
+  public static <T> RoundRobinDraw<T> create(Collection<T> items) throws IllegalArgumentException {
+    if (items == null || items.isEmpty()) {
+      throw new IllegalArgumentException("Collection must not be null or empty");
     }
     return new RoundRobinDraw<>(items);
   }
 
+  /**
+   * Returns the next element {@link T} of a {@link RoundRobinDraw<T> } instance.
+   * <p>
+   * If the last item of the instance has been already been provided, it will start again from the
+   * first item.
+   *
+   * @return an object of type {@link T}.
+   * @since 1.0.0
+   */
   public synchronized T next() {
     if (currentIndex == itemsAmount) {
       currentIndex = 0;

--- a/src/main/java/life/qbic/data/processing/config/RoundRobinDraw.java
+++ b/src/main/java/life/qbic/data/processing/config/RoundRobinDraw.java
@@ -1,0 +1,40 @@
+package life.qbic.data.processing.config;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * <b><class short description - 1 Line!></b>
+ *
+ * <p><More detailed description - When to use, what it solves, etc.></p>
+ *
+ * @since <version tag>
+ */
+public class RoundRobinDraw<T> {
+
+  private final ArrayList<T> items;
+  private final int itemsAmount;
+  private int currentIndex = 0;
+
+  private RoundRobinDraw(Collection<T> items) {
+    this.items = new ArrayList<>(items);
+    this.itemsAmount = items.size();
+  }
+
+  public static <T> RoundRobinDraw<T> create(Collection<T> items) {
+    if (items.isEmpty()) {
+      throw new IllegalArgumentException("Empty collection");
+    }
+    return new RoundRobinDraw<>(items);
+  }
+
+  public synchronized T next() {
+    if (currentIndex == itemsAmount) {
+      currentIndex = 0;
+    }
+    T value = items.get(currentIndex);
+    currentIndex++;
+    return value;
+  }
+
+}

--- a/src/main/java/life/qbic/data/processing/registration/RegistrationConfiguration.java
+++ b/src/main/java/life/qbic/data/processing/registration/RegistrationConfiguration.java
@@ -18,7 +18,7 @@ public class RegistrationConfiguration {
     if (!workingDirectory().toFile().isDirectory()) {
       throw new IllegalArgumentException(targetDirectory + " is not a directory");
     }
-    this.targetDirectory = Paths.get(Objects.requireNonNull(targetDirectory, "targetDirectory must not be null"));
+    this.targetDirectory = Paths.get(Objects.requireNonNull(targetDirectory, "targetDirectories must not be null"));
     if (!targetDirectory().toFile().exists()) {
       throw new IllegalArgumentException(targetDirectory + " does not exist");
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -41,7 +41,12 @@ processing.target.dir=${EVALUATION_DIR}
 # ---------------------------------
 evaluations.threads=2
 evaluation.working.dir=${EVALUATION_DIR}
-evaluation.target.dir=${OPENBIS_ETL_DIR}
+# Define one or more target directories here
+# Example single target dir:
+#    evaluation.target.dirs=/my/example/target/dir
+# Example multiple target dir:
+#   evaluation.target.dirs=/my/example/target/dir1,/my/example/target/dir2,/my/example/target/dir3
+evaluation.target.dirs=${OPENBIS_ETL_DIRS}
 evaluation.measurement-id.pattern=^(MS|NGS)Q[A-Z0-9]{4}[0-9]{3}[A-Z0-9]{2}-[0-9]*
 
 # ----------------


### PR DESCRIPTION
You can now provide a list of target ETL directories in the evaluation process config, the target directory will be then selected based on the simple round robin method.

Fix:
A race-condition caused by task directories not existing anymore, because another thread already processed and moved it.
The process request and evalation request threads were affected.