### PR TITLE
Support metadata file for registration

### DIFF
--- a/src/main/java/life/qbic/data/processing/AppConfig.java
+++ b/src/main/java/life/qbic/data/processing/AppConfig.java
@@ -36,15 +36,18 @@ class AppConfig {
   RegistrationWorkersConfig registrationWorkersConfig(
       @Value("${registration.threads}") int amountOfWorkers,
       @Value("${registration.working.dir}") String workingDirectory,
-      @Value("${registration.target.dir}") String targetDirectory) {
-    return new RegistrationWorkersConfig(amountOfWorkers, workingDirectory, targetDirectory);
+      @Value("${registration.target.dir}") String targetDirectory,
+      @Value("${registration.metadata.filename}") String metadataFileName) {
+    return new RegistrationWorkersConfig(amountOfWorkers, workingDirectory, targetDirectory,
+        metadataFileName);
   }
 
   @Bean
   RegistrationConfiguration registrationConfiguration(
       RegistrationWorkersConfig registrationWorkersConfig) {
     return new RegistrationConfiguration(registrationWorkersConfig.workingDirectory().toString(),
-        registrationWorkersConfig.targetDirectory().toString());
+        registrationWorkersConfig.targetDirectory().toString(),
+        registrationWorkersConfig.metadataFileName());
   }
 
   @Bean

--- a/src/main/java/life/qbic/data/processing/Application.java
+++ b/src/main/java/life/qbic/data/processing/Application.java
@@ -46,7 +46,7 @@ public class Application {
 
     List<ProcessRegistrationRequest> registrationWorkers = new LinkedList<>();
     for (int i=0; i<registrationWorkersConfig.amountOfWorkers(); i++) {
-      registrationWorkers.add(new ProcessRegistrationRequest(requestQueue, registrationConfiguration));
+      registrationWorkers.add(new ProcessRegistrationRequest(requestQueue, registrationConfiguration, globalConfig));
     }
 
     log.info("Registering {} processing workers...", processingWorkersConfig.threads());

--- a/src/main/java/life/qbic/data/processing/Provenance.java
+++ b/src/main/java/life/qbic/data/processing/Provenance.java
@@ -11,6 +11,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -41,6 +43,9 @@ public class Provenance {
 
   @JsonProperty("measurementId")
   public String qbicMeasurementID;
+
+  @JsonProperty("datasetFiles")
+  public List<String> datasetFiles;
 
   /**
    * A list of ordered processing folder stops the dataset has traversed and passed successfully.
@@ -93,6 +98,22 @@ public class Provenance {
     UNKNOWN_CONTENT,
     NOT_FOUND,
     IO_ERROR
+  }
+
+  public void addDatasetFiles(Collection<String> datasetFiles) {
+    Objects.requireNonNull(datasetFiles);
+    if (this.datasetFiles == null) {
+      this.datasetFiles = new ArrayList<>();
+    }
+    this.datasetFiles.addAll(datasetFiles);
+  }
+
+  public void addDatasetFile(String datasetFile) {
+    addDatasetFiles(Collections.singletonList(datasetFile));
+  }
+
+  public Collection<String> datasetFiles() {
+    return datasetFiles.stream().toList();
   }
 
   public static class ProvenanceException extends RuntimeException {

--- a/src/main/java/life/qbic/data/processing/config/RegistrationWorkersConfig.java
+++ b/src/main/java/life/qbic/data/processing/config/RegistrationWorkersConfig.java
@@ -11,7 +11,9 @@ public class RegistrationWorkersConfig {
 
   private final Path targetDirectory;
 
-  public RegistrationWorkersConfig(int threads, String workingDirectory, String targetDirectory) {
+  private final String metadataFileName;
+
+  public RegistrationWorkersConfig(int threads, String workingDirectory, String targetDirectory, String metadataFileName) {
     if (threads < 1) {
       throw new IllegalArgumentException("Number of threads must be greater than 0");
     }
@@ -26,6 +28,7 @@ public class RegistrationWorkersConfig {
     this.workingDirectory = directory;
     this.amountOfWorkers = threads;
     this.targetDirectory = targetDirectoryPath;
+    this.metadataFileName = metadataFileName;
   }
 
   public int amountOfWorkers() {
@@ -38,5 +41,9 @@ public class RegistrationWorkersConfig {
 
   public Path targetDirectory() {
     return this.targetDirectory;
+  }
+
+  public String metadataFileName() {
+    return this.metadataFileName;
   }
 }

--- a/src/main/java/life/qbic/data/processing/processing/ProcessingRequest.java
+++ b/src/main/java/life/qbic/data/processing/processing/ProcessingRequest.java
@@ -133,7 +133,7 @@ public class ProcessingRequest extends Thread {
     }
 
     Provenance finalProvenance = provenance;
-    packageDataset(taskDir);
+    //packageDataset(taskDir);
     taskDirContent.stream().filter(file -> !file.getName().equals(Provenance.FILE_NAME)).findFirst()
         .ifPresent(file -> {
           finalProvenance.addToHistory(taskDir.getAbsolutePath());

--- a/src/main/java/life/qbic/data/processing/registration/ErrorCode.java
+++ b/src/main/java/life/qbic/data/processing/registration/ErrorCode.java
@@ -9,5 +9,5 @@ package life.qbic.data.processing.registration;
  */
 public enum ErrorCode {
   METADATA_FILE_NOT_FOUND,
-  INCOMPLETE_METADATA, FILE_NOT_FOUND, IO_EXCEPTION
+  INCOMPLETE_METADATA, FILE_NOT_FOUND, MISSING_FILE_ENTRY, IO_EXCEPTION
 }

--- a/src/main/java/life/qbic/data/processing/registration/ErrorCode.java
+++ b/src/main/java/life/qbic/data/processing/registration/ErrorCode.java
@@ -1,0 +1,13 @@
+package life.qbic.data.processing.registration;
+
+/**
+ * <b><enum short description - 1 Line!></b>
+ *
+ * <p><More detailed description - When to use, what it solves, etc.></p>
+ *
+ * @since <version tag>
+ */
+public enum ErrorCode {
+  METADATA_FILE_NOT_FOUND,
+  INCOMPLETE_METADATA, FILE_NOT_FOUND, IO_EXCEPTION
+}

--- a/src/main/java/life/qbic/data/processing/registration/ProcessRegistrationRequest.java
+++ b/src/main/java/life/qbic/data/processing/registration/ProcessRegistrationRequest.java
@@ -3,13 +3,20 @@ package life.qbic.data.processing.registration;
 import static org.apache.logging.log4j.LogManager.getLogger;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import life.qbic.data.processing.ConcurrentRegistrationQueue;
+import life.qbic.data.processing.GlobalConfig;
 import life.qbic.data.processing.Provenance;
 import org.apache.logging.log4j.Logger;
 import org.springframework.lang.NonNull;
@@ -20,7 +27,8 @@ import org.springframework.lang.NonNull;
  * This must be the first process of handling a new incoming dataset. It will consume a processing
  * request item, that is then used to prepare the dataset for the following downstream processes.
  * <p>
- * The process polls the {@link ConcurrentRegistrationQueue} shared with the scanning thread.
+ * The process polls the {@link life.qbic.data.processing.ConcurrentRegistrationQueue} shared with
+ * the scanning thread.
  *
  * <p>
  * The process will do the following tasks:
@@ -40,43 +48,88 @@ public class ProcessRegistrationRequest extends Thread {
   private final ConcurrentRegistrationQueue registrationQueue;
   private final Path workingDirectory;
   private final Path targetDirectory;
+  private final String metadataFileName;
+  private final Path usersErrorDirectory;
   private AtomicBoolean active = new AtomicBoolean(false);
 
   public ProcessRegistrationRequest(@NonNull ConcurrentRegistrationQueue registrationQueue,
-      @NonNull RegistrationConfiguration configuration) {
+      @NonNull RegistrationConfiguration configuration, @NonNull GlobalConfig globalConfig) {
     this.setName(threadName.formatted(nextThreadNumber()));
     this.registrationQueue = registrationQueue;
     this.workingDirectory = configuration.workingDirectory();
     this.targetDirectory = configuration.targetDirectory();
+    this.metadataFileName = configuration.metadataFileName();
+    this.usersErrorDirectory = globalConfig.usersErrorDirectory();
   }
 
   private static int nextThreadNumber() {
     return threadNumber++;
   }
 
-  @Override
-  public void run() {
-    while (true) {
-      var request = registrationQueue.poll();
-      active.set(true);
-      log.info("Processing request: {}", request);
-      try {
-        Path taskDir = createTaskDirectory();
-        Path newLocation = taskDir.resolve(request.target().getFileName());
-        Files.move(request.target(), newLocation);
-        writeProvenanceInformation(taskDir, newLocation, request);
-        Files.move(taskDir, targetDirectory.resolve(taskDir.getFileName()));
-      } catch (RuntimeException e) {
-        log.error("Error moving task directory", e);
-        // TODO move back to user folder
-      } catch (IOException e) {
-        log.error("Error while processing registration request", e);
-        // TODO move back to user folder
-      } finally {
-        active.set(false);
-        log.info("Processing completed: {}", request);
+  private void moveBackToOrigin(Path target, Path usersHomePath, String reason) {
+    log.info("Moving back to original user directory: {}", target);
+    try {
+      Path taskDir = createTaskDirectory();
+      Files.move(target, taskDir.resolve(target.getFileName()));
+      var errorFile = taskDir.resolve("error.txt").toFile();
+      errorFile.createNewFile();
+      Files.writeString(errorFile.toPath(), reason);
+      usersHomePath.resolve(usersErrorDirectory).toFile().mkdir();
+      Files.move(taskDir,
+          usersHomePath.resolve(usersErrorDirectory)
+              .resolve(taskDir.toFile().getName()));
+    } catch (IOException e) {
+      log.error("Cannot move task to user intervention: %s".formatted(
+          usersHomePath.resolve(usersErrorDirectory)), e);
+    }
+  }
+
+  private void validateFileEntries(Collection<RegistrationMetadata> metadata, Path request)
+      throws ValidationException {
+    for (RegistrationMetadata metadataEntry : metadata) {
+      if (!request.resolve(Paths.get(metadataEntry.file())).toFile().exists()) {
+        throw new ValidationException(
+            "Unknown file reference in metadata: %s".formatted(metadataEntry.file()),
+            ErrorCode.FILE_NOT_FOUND);
       }
     }
+  }
+
+  private List<RegistrationMetadata> findAndParseMetadata(Path request) throws ValidationException {
+    Optional<File> metadataFile = findMetadataFile(request);
+    if (metadataFile.isEmpty()) {
+      throw new ValidationException("Metadata file does not exist",
+          ErrorCode.METADATA_FILE_NOT_FOUND);
+    }
+
+    List<String> content;
+    try {
+      content = new ArrayList<>(Files.readAllLines(Paths.get(metadataFile.get().getPath())));
+    } catch (IOException e) {
+      log.error("Error reading metadata file", e);
+      throw new ValidationException("Cannot read metadata file", ErrorCode.IO_EXCEPTION);
+    }
+
+    return content.stream().map(this::parseMetadataRow).toList();
+  }
+
+  private RegistrationMetadata parseMetadataRow(String value) throws ValidationException {
+    try {
+      var splitValues = value.split("\t");
+      return new RegistrationMetadata(splitValues[0], splitValues[1]);
+    } catch (IndexOutOfBoundsException e) {
+      log.error("Error parsing metadata row: %s".formatted(value), e);
+      throw new ValidationException("Cannot parse metadata entry", ErrorCode.INCOMPLETE_METADATA);
+    }
+  }
+
+  private Optional<File> findMetadataFile(Path path) {
+    for (File file : Objects.requireNonNull(path.toFile().listFiles())) {
+      if (file.isFile() && file.getName().endsWith(metadataFileName)) {
+        return Optional.of(file);
+      }
+    }
+    return Optional.empty();
   }
 
   private void writeProvenanceInformation(Path taskDir, Path newLocation,
@@ -110,6 +163,35 @@ public class ProcessRegistrationRequest extends Thread {
       }
     }
     log.debug("Task has been finished");
+  }
+
+  @Override
+  public void run() {
+    while (true) {
+      var request = registrationQueue.poll();
+      active.set(true);
+      log.info("Processing request: {}", request);
+      try {
+        var registrationMetadata = findAndParseMetadata(request.target());
+        validateFileEntries(registrationMetadata, request.target());
+        Path taskDir = createTaskDirectory();
+        Path newLocation = taskDir.resolve(request.target().getFileName());
+        Files.move(request.target(), newLocation);
+        writeProvenanceInformation(taskDir, newLocation, request);
+        Files.move(taskDir, targetDirectory.resolve(taskDir.getFileName()));
+      } catch (ValidationException e) {
+        moveBackToOrigin(request.target(), request.userPath(), e.getMessage());
+      } catch (RuntimeException e) {
+        log.error("Error moving task directory", e);
+        // TODO move back to user folder
+      } catch (IOException e) {
+        log.error("Error while processing registration request", e);
+        // TODO move back to user folder
+      } finally {
+        active.set(false);
+        log.info("Processing completed: {}", request);
+      }
+    }
   }
 
 }

--- a/src/main/java/life/qbic/data/processing/registration/RegistrationConfiguration.java
+++ b/src/main/java/life/qbic/data/processing/registration/RegistrationConfiguration.java
@@ -9,8 +9,9 @@ public class RegistrationConfiguration {
 
   private final Path workingDirectory;
   private final Path targetDirectory;
+  private final String metadataFileName;
 
-  public RegistrationConfiguration(String workingDirectory, String targetDirectory) {
+  public RegistrationConfiguration(String workingDirectory, String targetDirectory, String metadataFileName) {
     this.workingDirectory = Paths.get(Objects.requireNonNull(workingDirectory, "workingDirectory must not be null"));
     if (!workingDirectory().toFile().exists()) {
       throw new IllegalArgumentException(targetDirectory + " does not exist");
@@ -25,6 +26,10 @@ public class RegistrationConfiguration {
     if (!targetDirectory().toFile().isDirectory()) {
       throw new IllegalArgumentException(targetDirectory + " is not a directory");
     }
+    if (metadataFileName == null || metadataFileName.isEmpty()) {
+      throw new IllegalArgumentException("metadataFileName must not be null or empty");
+    }
+    this.metadataFileName = metadataFileName;
   }
 
   public Path workingDirectory() {
@@ -34,4 +39,6 @@ public class RegistrationConfiguration {
   public Path targetDirectory() {
     return targetDirectory;
   }
+
+  public String metadataFileName() { return metadataFileName; }
 }

--- a/src/main/java/life/qbic/data/processing/registration/RegistrationMetadata.java
+++ b/src/main/java/life/qbic/data/processing/registration/RegistrationMetadata.java
@@ -1,0 +1,12 @@
+package life.qbic.data.processing.registration;
+
+/**
+ * <b><class short description - 1 Line!></b>
+ *
+ * <p><More detailed description - When to use, what it solves, etc.></p>
+ *
+ * @since <version tag>
+ */
+public record RegistrationMetadata(String measurementId, String file) {
+
+}

--- a/src/main/java/life/qbic/data/processing/registration/ValidationException.java
+++ b/src/main/java/life/qbic/data/processing/registration/ValidationException.java
@@ -1,0 +1,26 @@
+package life.qbic.data.processing.registration;
+
+/**
+ * <b><class short description - 1 Line!></b>
+ *
+ * <p><More detailed description - When to use, what it solves, etc.></p>
+ *
+ * @since <version tag>
+ */
+public class ValidationException extends RuntimeException {
+
+  private final ErrorCode errorCode;
+
+  public ValidationException(ErrorCode errorCode) {
+    this.errorCode = errorCode;
+  }
+
+  public ValidationException(String message, ErrorCode errorCode) {
+    super(message);
+    this.errorCode = errorCode;
+  }
+
+  public ErrorCode errorCode() {
+    return errorCode;
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,7 +27,7 @@ scanner.interval=1000
 # Settings for the registration worker threads
 #----------------
 registration.threads=2
-registration.metadata.filename=metadata
+registration.metadata.filename=metadata.txt
 registration.working.dir=${WORKING_DIR:}
 registration.target.dir=${PROCESSING_DIR:}
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,6 +27,7 @@ scanner.interval=1000
 # Settings for the registration worker threads
 #----------------
 registration.threads=2
+registration.metadata.filename=metadata
 registration.working.dir=${WORKING_DIR:}
 registration.target.dir=${PROCESSING_DIR:}
 


### PR DESCRIPTION
Adds support for a metadata file, that contains a tab-separated
list of measurement id and file pairs, which will be used for registration.
Files that have the same measurement ID entry will be aggregated and processed as one task. 