### PR TITLE
Skip registration for files and ignore files with insufficient rights

### DIFF
--- a/src/main/java/life/qbic/data/processing/scanner/Scanner.java
+++ b/src/main/java/life/qbic/data/processing/scanner/Scanner.java
@@ -103,6 +103,7 @@ public class Scanner extends Thread {
     return userProcessDirectories.parallelStream()
         .map(Path::toFile)
         .filter(this::matchesAccessRightsCriteria)
+        .filter(this::matchesRegistrationCriteria)
         .map(file -> createRequests(file.listFiles(), file.toPath())).flatMap(
             Collection::stream).toList();
   }
@@ -119,12 +120,18 @@ public class Scanner extends Thread {
     return true;
   }
 
+  private boolean matchesRegistrationCriteria(File file) {
+    if (file.isHidden()) {
+      return false;
+    }
+    return !file.isFile();
+  }
+
   private List<RegistrationRequest> createRequests(File[] files, Path userDirectory) {
     if (files == null || files.length == 0) {
       return new ArrayList<>();
     }
-    return Arrays.stream(files).filter(file -> !file.isHidden()).filter(File::isDirectory)
-        .map(file -> createRequest(file, userDirectory)).toList();
+    return Arrays.stream(files).map(file -> createRequest(file, userDirectory)).toList();
   }
 
   private RegistrationRequest createRequest(File file, Path userDirectory) {

--- a/src/main/java/life/qbic/data/processing/scanner/Scanner.java
+++ b/src/main/java/life/qbic/data/processing/scanner/Scanner.java
@@ -124,7 +124,7 @@ public class Scanner extends Thread {
     if (file.isHidden()) {
       return false;
     }
-    return !file.isFile();
+    return file.isDirectory();
   }
 
   private List<RegistrationRequest> createRequests(File[] files, Path userDirectory) {

--- a/src/main/java/life/qbic/data/processing/scanner/Scanner.java
+++ b/src/main/java/life/qbic/data/processing/scanner/Scanner.java
@@ -102,6 +102,13 @@ public class Scanner extends Thread {
   private List<RegistrationRequest> detectDataForRegistration() {
     return userProcessDirectories.parallelStream()
         .map(Path::toFile)
+        .filter(file -> {
+          if (!file.canWrite()) {
+            log.error("Cannot write to file '{}'", file);
+            return false;
+          }
+          return true;
+        } )
         .map(file -> createRequests(file.listFiles(), file.toPath())).flatMap(
             Collection::stream).toList();
   }

--- a/src/main/java/life/qbic/data/processing/scanner/Scanner.java
+++ b/src/main/java/life/qbic/data/processing/scanner/Scanner.java
@@ -102,15 +102,21 @@ public class Scanner extends Thread {
   private List<RegistrationRequest> detectDataForRegistration() {
     return userProcessDirectories.parallelStream()
         .map(Path::toFile)
-        .filter(file -> {
-          if (!file.canWrite()) {
-            log.error("Cannot write to file '{}'", file);
-            return false;
-          }
-          return true;
-        } )
+        .filter(this::matchesAccessRightsCriteria)
         .map(file -> createRequests(file.listFiles(), file.toPath())).flatMap(
             Collection::stream).toList();
+  }
+
+  private boolean matchesAccessRightsCriteria(File file) {
+    if (!file.canWrite()) {
+      log.error("Cannot write to file '{}'", file);
+      return false;
+    }
+    if (!file.canExecute()) {
+      log.error("Cannot execute file '{}'", file);
+      return false;
+    }
+    return true;
   }
 
   private List<RegistrationRequest> createRequests(File[] files, Path userDirectory) {

--- a/src/main/java/life/qbic/data/processing/scanner/Scanner.java
+++ b/src/main/java/life/qbic/data/processing/scanner/Scanner.java
@@ -110,7 +110,7 @@ public class Scanner extends Thread {
     if (files == null || files.length == 0) {
       return new ArrayList<>();
     }
-    return Arrays.stream(files).filter(file -> !file.isHidden())
+    return Arrays.stream(files).filter(file -> !file.isHidden()).filter(File::isDirectory)
         .map(file -> createRequest(file, userDirectory)).toList();
   }
 


### PR DESCRIPTION
Currently the registration fails silently if the dataset to register
is not wrapped in a directory.

Also, the dataset registration fails, when the application has not sufficient rights to execute and write to the dataset folder (e.g. wrong access group, etc).

 