### PR TITLE
Prepare release 0.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,13 @@
       <artifactId>jackson-databind</artifactId>
       <version>2.17.0</version>
     </dependency>
+
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.16.1</version>
+    </dependency>
+
   </dependencies>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
Since the target ETL dropbox might be on a different file system, a simple move wont work.

This PR introduces the commons-io lib from Apache, that provides a simple FileUtils class with directory copy. After a successful copy and marker file creation, the task folder is deleted from the evaluation working directory.